### PR TITLE
add platform when building docker image for building on arm64 (and other) platforms

### DIFF
--- a/logan/docker-images/v1.0/oraclelinux/8/Dockerfile
+++ b/logan/docker-images/v1.0/oraclelinux/8/Dockerfile
@@ -1,4 +1,4 @@
-FROM container-registry.oracle.com/os/oraclelinux:8
+FROM --platform=linux/amd64 container-registry.oracle.com/os/oraclelinux:8
 
 USER root
 WORKDIR /fluentd


### PR DESCRIPTION
when building image on non-linux (i.e. mac/arm), it defaults to arm64, causing image crash when launching.  explicitly specifying the platform prevents this