### PR TITLE
 [Quick Fix] Updates to Dashboard Import Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ charts/**/charts/
 
 # zip artifacts
 releases/
+
+# vscode
+.vscode

--- a/terraform/oke/inputs.tf
+++ b/terraform/oke/inputs.tf
@@ -68,13 +68,19 @@ variable "boat_tenancy_ocid" {
 }
 
 ####
-##  Dynamic Group and Policies
+##  Optional Inputs
 ####
 
 # Option to create Dynamic Group and Policies
 variable "opt_create_dynamicGroup_and_policies" {
   type    = bool
   default = false
+}
+
+# Option to import dashboards
+variable "opt_import_dashboards" {
+  type    = bool
+  default = true
 }
 
 ####

--- a/terraform/oke/main.tf
+++ b/terraform/oke/main.tf
@@ -14,7 +14,7 @@ locals {
   ## Module dependencies should be included here as well so a module does not run when it's depenedent moudle is disabled
 
   module_controls_enable_livelab_module    = alltrue([var.toggle_livelab_module, var.livelab_switch])
-  module_controls_enable_dashboards_module = alltrue([var.toggle_dashboards_module])
+  module_controls_enable_dashboards_module = alltrue([var.toggle_dashboards_module, var.opt_import_dashboards])
   module_controls_enable_iam_module        = alltrue([var.toggle_iam_module, var.opt_create_dynamicGroup_and_policies, !var.livelab_switch])
   module_controls_enable_logan_module      = alltrue([var.toggle_logan_module])
   module_controls_enable_mgmt_agent_module = alltrue([var.toggle_mgmt_agent_module])
@@ -34,14 +34,6 @@ module "livelab" {
   /* providers = {
     oci = oci.home_region
   } */
-}
-
-// Import Kubernetes Dashboards
-module "import_kubernetes_dashbords" {
-  source           = "./modules/dashboards"
-  compartment_ocid = var.oci_onm_compartment_ocid
-
-  count = local.module_controls_enable_dashboards_module ? 1 : 0
 }
 
 // Create Required Polcies and Dynamic Group
@@ -102,4 +94,13 @@ module "helm_release" {
   oke_cluster_entity_ocid        = var.oke_cluster_entity_ocid
 
   count = local.module_controls_enable_helm_module ? 1 : 0
+}
+
+// Import Kubernetes Dashboards
+module "import_kubernetes_dashbords" {
+  source           = "./modules/dashboards"
+  compartment_ocid = var.oci_onm_compartment_ocid
+
+  count = local.module_controls_enable_dashboards_module ? 1 : 0
+  depends_on = [ module.helm_release ]
 }

--- a/terraform/oke/schema.yaml
+++ b/terraform/oke/schema.yaml
@@ -45,7 +45,7 @@ variableGroups:
       - stack_deployment_option
     visible: false
 
-  - title: Select an OKE cluster deployed in this region to start monitoring.
+  - title: Select an OKE cluster deployed in this region to start monitoring
     description: "Use CLI (Helm) if your cluster does not have a public API endpoint or if it's restricted from accessing container-registry.oracle.com. See: https://github.com/oracle-quickstart/oci-kubernetes-monitoring"
     variables:
       - oke_compartment_ocid
@@ -61,7 +61,7 @@ variableGroups:
     - oci_la_logGroup_name
     - fluentd_baseDir_path
 
-  - title: Optional Inputs
+  - title: Advanced Configuration
     variables:
       - opt_create_dynamicGroup_and_policies
       - opt_import_dashboards
@@ -196,7 +196,7 @@ variables:
   # Option to create Dynamic Group and Policies
   opt_create_dynamicGroup_and_policies:
     type: boolean
-    title: Select this check box to create dynamic groups and policies that are required for deploying the monitoring solution.
+    title: Select this check box to create OCI IAM dynamic groups and policies which are required for the monitoring solution
     #description: "Ref: https://github.com/oracle-quickstart/oci-kubernetes-monitoring#pre-requisites"
     description: "Note: If node pools and the OKE cluster are in different compartments, then the dynamic group definition must be updated."
     default: false
@@ -206,5 +206,6 @@ variables:
   opt_import_dashboards:
     type: boolean
     title: Select this check box to import dashboards
+    description: "Note: You may need to manually clean up the dashboards when you destory the stack as dashboards will not be deleted automatically."
     default: true
     required: true

--- a/terraform/oke/schema.yaml
+++ b/terraform/oke/schema.yaml
@@ -61,9 +61,10 @@ variableGroups:
     - oci_la_logGroup_name
     - fluentd_baseDir_path
 
-  - title: OCI IAM Policies and Dynamic Groups (Optional)
+  - title: Optional Inputs
     variables:
       - opt_create_dynamicGroup_and_policies
+      - opt_import_dashboards
 
 variables:
 
@@ -189,7 +190,7 @@ variables:
         - livelab_switch
 
   ####
-  ##  Pre-requisites
+  ##  Optional Inputs
   ####
 
   # Option to create Dynamic Group and Policies
@@ -199,4 +200,11 @@ variables:
     #description: "Ref: https://github.com/oracle-quickstart/oci-kubernetes-monitoring#pre-requisites"
     description: "Note: If node pools and the OKE cluster are in different compartments, then the dynamic group definition must be updated."
     default: false
-    required: true    
+    required: true
+
+  # Option to create Dynamic Group and Policies
+  opt_import_dashboards:
+    type: boolean
+    title: Select this check box to import dashboards
+    default: true
+    required: true


### PR DESCRIPTION
- Quick Fix: Dashboard imports only run post successful helm deployment
- Dashboard import is now optional (enabled by default)