### PR TITLE
Adding toleration for nodes with custom taints

### DIFF
--- a/charts/logan/templates/fluentd-daemonset.yaml
+++ b/charts/logan/templates/fluentd-daemonset.yaml
@@ -35,6 +35,7 @@ spec:
         effect: NoSchedule
       - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
+      - operator: Exists
       {{- if $imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.image.imagePullSecrets }}


### PR DESCRIPTION
This fixes the DaemonSet not being deployed on nodes with custom taint.