### PR TITLE
Remove conditional cluster name "onm3h-demo"

### DIFF
--- a/terraform/modules/dashboards/dashboards_json/service-type-lb.json
+++ b/terraform/modules/dashboards/dashboards_json/service-type-lb.json
@@ -1077,7 +1077,7 @@
                   "compartmentId": "$(params.compartmentId)",
                   "endTime": "$(params.time.end)",
                   "maxDataPoints": "useIntervalExact",
-                  "mql": "nodeMemoryUsage[1m]{clusterName = \"onm3h-demo\"}.mean()",
+                  "mql": "nodeMemoryUsage[1m].mean()",
                   "namespace": "mgmtagent_kubernetes_metrics",
                   "regionName": "$(params.regionName)",
                   "startTime": "$(params.time.start)"


### PR DESCRIPTION
Removed the conditional check for the cluster name "onm3h-demo" from the widget  Node Memory Usage configuration. This condition caused the widget to be empty when the cluster name did not match "onm3h-demo". Each cluster has its own unique name, so this hard-coded condition was unnecessary and led to incorrect widget behavior.