### PR TITLE
fix: helm upgrade fails when imagePullSecrets is not defined

### DIFF
--- a/charts/logan/templates/discovery-cronjob.yaml
+++ b/charts/logan/templates/discovery-cronjob.yaml
@@ -22,8 +22,10 @@ spec:
         spec:
           restartPolicy: {{ .Values.k8sDiscovery.objects.restartPolicy }}
           serviceAccountName: {{ $serviceAccount }}
+          {{- if .Values.image.imagePullSecrets }}
           imagePullSecrets:
           - name: {{ .Values.image.imagePullSecrets }}
+          {{- end }}
           containers:
           - name: k8-discovery-job
             image: {{ .Values.image.url }}


### PR DESCRIPTION
**Error During Helm upgrade:**

`client.go:693: [debug] Patch DaemonSet "oci-onm-dev-logan" in namespace oci-onm-dev
client.go:425: [debug] error updating the resource "oci-onm-dev-discovery":
         failed to create patch: map: map[] does not contain declared merge key: name
upgrade.go:468: [debug] warning: Upgrade "oci-kubernetes-monitoring-dev" failed: failed to create patch: map: map[] does not contain declared merge key: name
Error: UPGRADE FAILED: failed to create patch: map: map[] does not contain declared merge key: name
helm.go:84: [debug] failed to create patch: map: map[] does not contain declared merge key: name
helm.sh/helm/v3/pkg/kube.(*Client).Update
        helm.sh/helm/v3/pkg/kube/client.go:438
helm.sh/helm/v3/pkg/action.(*Upgrade).releasingUpgrade
        helm.sh/helm/v3/pkg/action/upgrade.go:410
runtime.goexit
        runtime/asm_arm64.s:1222
UPGRADE FAILED
main.newUpgradeCmd.func2
        helm.sh/helm/v3/cmd/helm/upgrade.go:238
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.8.0/command.go:983
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.8.0/command.go:1115
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.8.0/command.go:1039
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
        runtime/proc.go:271
runtime.goexit
        runtime/asm_arm64.s:1222`